### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 **Install with cdn**
 
 ```html
-<link rel="stylesheet" href="https://cdn.rawgit.com/mightyCrow/wenk/master/dist/wenk.min.css">
+<link rel="stylesheet" href="https://unpkg.com/wenk/dist/wenk.css">
 ```
 
 **Install with Bower**

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo lol nope yolo",
     "build": "gulp build",
-    "demo": "gulp demo",
+    "start": "gulp demo",
     "dev": "gulp",
     "size": "gulp size",
     "deploy": "gulp build && gh-pages -d demo"


### PR DESCRIPTION
Not a deal breaker these.

but better standard to use the short hand script `npm start` to denote the goto script

and take a look at https://unpkg.com/ for details - fast becoming npm cdn standard - rather than using the unpublished git master.
